### PR TITLE
Introduce Powershell Script ( based on pr #2 )

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,12 @@
         color: blue;
     }
 
-    h3 {
-        text-align: left;
-        padding-left: 15px;
+    #headerDiv {
+        margin-bottom: 1em;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-direction: row;
     }
 
     #bodyWrapper {
@@ -115,11 +118,15 @@
         max-width: 80%;
     }
 
+    table.params {
+        margin: 10px auto;
+    }
+
     .params {
         border: 1px solid;
     }
 
-    .planDiv {
+    .planDiv, .psPlanDiv {
         border: 1px solid;
         margin: 10px auto;
         min-width: 1000px;
@@ -158,7 +165,10 @@
         <h1>
           SharpCap Eclipse Sequence Creator
         </h1>
-        <h3>Requires <a href="https://www.sharpcap.co.uk/">SharpCap Pro</a> version 4.1.11947 or newer!</h3>
+        <div id="headerDiv">
+            <h3>Requires <a href="https://www.sharpcap.co.uk/">SharpCap Pro</a> version 4.1.11947 or newer!</h3>
+            <input type="button" value="Download REQUIRED Powershell Companion Script" id="psDownloadButton" style="max-width: 45%;" onClick="downloadPSScript();" />
+        </div>
         <ul class="topMenu">
             <li><a id="MenuNotes" href="javascript://" onClick="toggleDiv(this);" class='active'>Notes</a></li>
             <li><a id="MenuInstructions" href="javascript://" onClick="toggleDiv(this);">Instructions</a></li>
@@ -189,9 +199,9 @@
                 <li>Note the <i>Partial</i> and <i>Full</i> <i>Begin</i> and <i>End</i> times provided on the left side of the map.</li>
                 <li>Enter the observing site local times under <span class="code">Eclipse Times</span> below, in 24 hour, HH:MM:SS format.</li>
                 <li>Adjust the <span class="code">Intervals</span> and <span class="code">Camera Settings</span> as desired below.<br />
-                    <b>Notes:</b>
+                    <em>Notes:</em>
                     <ul>
-                        <li><span class="code">Partial Eclipse Count</span> <b>(recommended)</b> generates evenly spaced collections based on partial eclipse percentage, starting 1 minutes into the eclipse.</li>
+                        <li><span class="code">Partial Eclipse Count</span> <em>(recommended)</em> generates evenly spaced collections based on partial eclipse percentage, starting 1 minutes into the eclipse.</li>
                         <li><span class="code">Partial Eclipse Interval</span> generates evenly space collections based on time alone, with no concern for even partial percentage.</li>
                         <li><b>The two cannot be used at the same time.</b></li>
                     </ul>
@@ -210,6 +220,15 @@
                 </li>
                 <li>Monitor for an Alert sound, and banner at the top to Remove or Apply the Solar Filter around the time of Totality.</li>
             </ol>
+
+            <h4><em>Optional:</em> Download the Powershell script and assets</h4>
+            <ol>
+                <li>Download Powershell script <a href="javascript://" onClick="downloadPSScript();">april-2024-solar-eclipse.ps1</a></li>
+                <li>Copy the script to <span class="code">{SHARPCAP_INSTALL_FOLDER}\scripts\eclipse\</span> (.e.g. <span class="code">C:\Program Files\SharpCap 4.1 (64 bit)\scripts\eclipse\</span>)</li>
+                <li>Generate a sequence</li>
+            </ol>
+            <p><em>Note: The Powershell script runs separately from the SharpCap Eclipse Sequencer script. Ending the SharpCap Eclipse Sequencer script will not terminate the Powershell script.</em></p>
+            <p><em>However, the Powershell script will terminate on its own about 5 seconds after the final scheduled audiable alert.</em></p>
         </div>
         <table id="wrapperTable"><tr style="vertical-align: top;"><td>
             <table class="params">
@@ -262,6 +281,28 @@
                         </select><input type='hidden' id='totalityInterval' value='1'/>
                     </td></tr>
                 </table>
+
+                <table class="params">
+                    <tr><th colspan="2" class="headerBlock">Powershell Script Config</th></tr>
+                    <tr>
+                        <td class="label"><label for="generatePSConfig">Generate Powershell Script Config</label></td>
+                        <td>
+                            <select id="generatePSConfig" onChange="checkPSConfigOptions();">
+                                <option value="Yes" selected="selected">Yes</option>
+                                <option value="No">No</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="label"><label for="psConfigOptionNotifications">Display Windows Notifications</label></td>
+                        <td>
+                            <select id="psConfigOptionNotifications" class="psConfigOption" onChange="hideOutput();">
+                                <option value="Yes" selected="selected">Yes</option>
+                                <option value="No">No</option>
+                            </select>
+                        </td>
+                    </tr>
+                </table>
             </td><td>
             <table class="params">
                 <th colspan="2" class="headerBlock">Camera Settings</th>
@@ -280,17 +321,20 @@
         </th></tr></table>
         <div class="planDiv" id="partialPlanDiv"><h3 class="headerBlock">Partial Phase Collection Plan :: repeat <span id="partialPlanHeader"></span> before and after Totality.</h3><table class="planTable" id="partialPlan"></table><input type='button' class="wideButton" value="Add Partial Plan Row" onClick='addPlanLine("partialPlan")' /></div>
         <div class="planDiv" id="bailysPlanDiv"><h3 class="headerBlock">Baily's Beads Collection Plan :: repeat every <input id="bailysDelay" onChange="hideOutput();" type="number" value="0" min="0"/> seconds for <span id="bailysPlanHeader"></span> on either side of Totality.</h3><table class="planTable" id="bailysPlan"></table><input type='button' class="wideButton" value="Add Bailys Plan Row" onClick='addPlanLine("bailysPlan")' /></div>
-        <div class="planDiv" id="totalityPlanDiv"><h3 class="headerBlock">Totality Collection Plan :: repeat repeat every <input id="totalityDelay" onChange="hideOutput();" type="number" value="0" min="0"/> seconds during Totality.</h3><table class="planTable" id="totalityPlan"></table><input type='button' class="wideButton" value="Add Totality Plan Row" onClick='addPlanLine("totalityPlan")' /></div>
+        <div class="planDiv" id="totalityPlanDiv"><h3 class="headerBlock">Totality Collection Plan :: repeat every <input id="totalityDelay" onChange="hideOutput();" type="number" value="0" min="0"/> seconds during Totality.</h3><table class="planTable" id="totalityPlan"></table><input type='button' class="wideButton" value="Add Totality Plan Row" onClick='addPlanLine("totalityPlan")' /></div>
         <input type="button" style="max-width: 45%; margin: 30px auto; padding: 30px;" value="Generate Sequence" id="generateButton" onClick="generateSharpCap();"/>
 
         <div class="planDiv" id="sequenceDiv" style="display: none;">
             <h3 class="headerBlock">Generated Sequence</h3>
-            <input type="button" value="Copy Sequence to Clipboard" id="clipboardButton" style="margin: 15px 15px 0 15px; max-width: 45%;" onClick="copyToClipboard();" /><input type="button" value="Download SharpCap Sequence" id="downloadButton" style="max-width: 45%;" onClick="downloadSequence();" />
-            <textarea id="SharpCapSequence" style="width: 98%; height: 200px;" readonly="readonly"
+            <input type="button" value="Copy Sequence to Clipboard" id="clipboardButton" style="margin: 15px 15px 0 15px; max-width: 45%;" onClick="copyToClipboard();" /><input type="button" value="Download SharpCap Sequence" id="downloadButton" style="max-width: 45%;" onClick="downloadSequence();" /><input type="button" value="Download REQUIRED Powershell Companion Script" id="psDownloadButton2" style="margin: 15px 15px 0 0; max-width: 45%; float: right;" onClick="downloadPSScript();" />
+            <textarea id="SharpCapSequence" style="width: 98%; height: 200px; margin: 10px auto; display: block;" readonly="readonly"
             placeholder="SharpCap sequence will appear here."></textarea>
         </div>
     </div>
     <script type="text/javascript">
+        window.onerror = function (message,url,line,col,error) {
+            console.log("FAILURE: "+message+"\n"+url+"\nLine: "+line+"\ncolumn: "+col+"\n"+error);
+        }
         function uuidv4() {
             return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
                 (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
@@ -331,52 +375,50 @@
             let pmap = { "partialCount": "partialInterval", "partialInterval": "partialCount" };
             let e = document.getElementById(t);
             t = t.replace(/[A-Z].*$/,"");
-            try {
-                if(e.value==0) {
-                    if(t.match("partial")) {
-                        let pi=document.getElementById("partialInterval").value;
-                        let pc=document.getElementById("partialCount").value;
-                        if(pi==0 && pc==0) {
-                            document.getElementById(t+"PlanDiv").style.display="none";
-                            document.getElementById("partial_begins").classList.remove("goodInput");
-                            document.getElementById("partial_begins").classList.remove("badInput");
-                            document.getElementById("partial_begins").classList.add("disabledInput");
-                            document.getElementById("partial_begins").readonly="readonly";
-                            document.getElementById("partial_ends").classList.remove("goodInput");
-                            document.getElementById("partial_ends").classList.remove("badInput");
-                            document.getElementById("partial_ends").classList.add("disabledInput");
-                            document.getElementById("partial_ends").readonly="readonly";
-                        } else {
-                            document.getElementById(t+"PlanDiv").style.display="block";
-                            document.getElementById(t+"PlanHeader").innerHTML = e.options[e.selectedIndex].innerHTML;
-                            if(document.getElementById(t+"Plan").rows.length==0)
-                                addPlanLine(t+"Plan");
-                            document.getElementById("partial_begins").removeAttribute('readonly');
-                            document.getElementById("partial_ends").removeAttribute('readonly');
-                            verifyTime(document.getElementById("partial_begins"));
-                            verifyTime(document.getElementById("partial_ends"));
-                        }
+            if(e.value==0) {
+                if(t.match("partial")) {
+                    let pi=document.getElementById("partialInterval").value;
+                    let pc=document.getElementById("partialCount").value;
+                    if(pi==0 && pc==0) {
+                        document.getElementById( t + "PlanDiv" ).style.display="none";
+                        document.getElementById("partial_begins").classList.remove("goodInput");
+                        document.getElementById("partial_begins").classList.remove("badInput");
+                        document.getElementById("partial_begins").classList.add("disabledInput");
+                        document.getElementById("partial_begins").readonly="readonly";
+                        document.getElementById("partial_ends").classList.remove("goodInput");
+                        document.getElementById("partial_ends").classList.remove("badInput");
+                        document.getElementById("partial_ends").classList.add("disabledInput");
+                        document.getElementById("partial_ends").readonly="readonly";
                     } else {
-                        document.getElementById(t+"PlanDiv").style.display="none";
-                    }
-                } else {
-                    var phPost = "";
-                    if(t.match("partial"))
-                        document.getElementById(pmap[e.id]).value = 0;
-                    document.getElementById(t+"PlanDiv").style.display="block";
-                    document.getElementById(t+"PlanHeader").innerHTML = e.options[e.selectedIndex].innerHTML + phPost;
-                    if(document.getElementById(t+"Plan").rows.length==0)
-                        addPlanLine(t+"Plan");
-                    if(t=="partial") {
+                        document.getElementById( t + "PlanDiv" ).style.display="block";
+                        document.getElementById(t+"PlanHeader").innerHTML = e.options[e.selectedIndex].innerHTML;
+                        if(document.getElementById(t+"Plan").rows.length==0)
+                            addPlanLine(t+"Plan");
                         document.getElementById("partial_begins").removeAttribute('readonly');
                         document.getElementById("partial_ends").removeAttribute('readonly');
                         verifyTime(document.getElementById("partial_begins"));
                         verifyTime(document.getElementById("partial_ends"));
                     }
+                } else {
+                    document.getElementById(t+"PlanDiv").style.display="none";
                 }
-            } catch(err) {
-                console.log("Err: "+t+" :: "+err);
+            } else {
+                if(t.match("partial"))
+                    document.getElementById(pmap[e.id]).value = 0;
+                document.getElementById(t+"PlanDiv").style.display="block";
+                document.getElementById(t+"PlanHeader").innerHTML = e.options[e.selectedIndex].innerHTML;
+                if(document.getElementById(t+"Plan").rows.length==0)
+                    addPlanLine(t+"Plan");
+                if(t=="partial") {
+                    document.getElementById("partial_begins").removeAttribute('readonly');
+                    document.getElementById("partial_ends").removeAttribute('readonly');
+                    document.getElementById("partial_begins").classList.remove('disabledInput');
+                    document.getElementById("partial_ends").classList.remove('disabledInput');
+                    verifyTime(document.getElementById("partial_begins"));
+                    verifyTime(document.getElementById("partial_ends"));
+                }
             }
+
             hideOutput();
         }
 
@@ -387,16 +429,16 @@
 
         function verifyTime(t) {
             hideOutput();
-            let v=/^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(:[0-5][0-9])$/.test(t.value);
-            if(v) {
-                t.classList.add("goodInput");
-                t.classList.remove("badInput");
-                t.classList.remove("disabledInput");
-                saveState();
-            } else {
-                t.classList.remove("goodInput");
-                t.classList.add("badInput");
-                t.classList.remove("disabledInput");
+            if(!(t.classList.contains("disabledInput"))) {
+                let v = timeRegEx.test(t.value);
+                if(v) {
+                    t.classList.add("goodInput");
+                    t.classList.remove("badInput");
+                    saveState();
+                } else {
+                    t.classList.remove("goodInput");
+                    t.classList.add("badInput");
+                }
             }
         }
 
@@ -463,8 +505,33 @@
         }
 
         function generateSharpCap() {
-            var now = new Date();
-            var preOutput = new Array(
+            const partialInterval = parseInt(document.getElementById("partialInterval").value),
+                partialCount = parseInt(document.getElementById("partialCount").value),
+                bailysInterval = parseInt(document.getElementById("bailysInterval").value);
+            try {
+                if(partialInterval>0 || partialCount>0) {
+                    ["partial_begins", "partial_ends"].forEach((t) => {
+                        let v = timeRegEx.test(document.getElementById(t).value);
+                        if(document.getElementById(t).value=="" || !v) {
+                            alert("  Sorry, please fill in the "+t.split("_").join(" ")+" timestamp\n    in 24 hour, HH:MM:SS format.");
+                            throw BreakException;
+                        }
+                    });
+                }
+                ["full_begins", "full_ends"].forEach((t) => {
+                    let v = timeRegEx.test(document.getElementById(t).value);
+                    if(document.getElementById(t).value=="" || !v) {
+                        alert("  Sorry, please fill in the "+t.split("_").join(" ")+" timestamp\n    in 24 hour, HH:MM:SS format.");
+                        throw BreakException;
+                    }
+                });
+            } catch(e) {
+                console.log("Error, missing / invalid parameters.\n"+e);
+                return;
+            }
+
+            var now = new Date(),
+                preOutput = [
                 "SEQUENCE",
                 "    # Generated by: ",
                 "    # linuxkidd's SharpCap Eclipse Sequencer",
@@ -479,46 +546,37 @@
                 "    # (C3) Full ends:      "+document.getElementById("full_ends").value,
                 "    # (C4) Partial ends:   "+document.getElementById("partial_ends").value,
                 "    #"
-                );
-            ["bailysInterval","partialCount","partialInterval","gain","offset","output", "profile"].forEach((a) => {
+                ],
+                SharpCapSequenceEl = document.getElementById( 'SharpCapSequence' ),
+                generatePSConfigEl = document.getElementById( 'generatePSConfig' );
+
+            ["bailysInterval","partialCount","partialInterval","gain","offset","output","profile","generatePSConfig","psConfigOptionNotifications"].forEach((a) => {
                 preOutput.push("    # "+a+": "+document.getElementById(a).value);
             });
             preOutput.push("    #","    #");
             var output = new Array();
             var indent = 4;
-            let partialInterval = parseInt(document.getElementById("partialInterval").value);
-            let partialCount = parseInt(document.getElementById("partialCount").value);
-            let bailysInterval = parseInt(document.getElementById("bailysInterval").value);
-            let totalityDuration = timeToSeconds(document.getElementById("full_ends").value) - timeToSeconds(document.getElementById("full_begins").value);
+
+            const c1 = document.getElementById("partial_begins").value,
+                c2 = document.getElementById("full_begins").value,
+                c3 = document.getElementById("full_ends").value,
+                c4 = document.getElementById("partial_ends").value,
+                c1_seconds = timeToSeconds(c1),
+                c2_seconds = timeToSeconds(c2),
+                c3_seconds = timeToSeconds(c3),
+                c4_seconds = timeToSeconds(c4),
+                totalityDuration = c3_seconds - c2_seconds;
             var preInterval = partialInterval;
             var postInterval = partialInterval;
             if(partialCount>0) {
-                let preDuration = timeToSeconds(document.getElementById("full_begins").value) - timeToSeconds(document.getElementById("partial_begins").value) - bailysInterval - 120;
-                let postDuration = timeToSeconds(document.getElementById("partial_ends").value) - timeToSeconds(document.getElementById("full_ends").value) - bailysInterval - 120;
-                preInterval = preDuration / partialCount;
+                const
+                    preDuration = c2_seconds - c1_seconds - bailysInterval - 120,
+                    postDuration = c4_seconds - c3_seconds - bailysInterval - 120;
+                preInterval = preDuration / partialCount,
                 postInterval = postDuration / partialCount;
             }
 
-            try {
-                if(partialInterval>0 || partialCount>0) {
-                    ["partial_begins", "partial_ends"].forEach((t) => {
-                        let v = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(:[0-5][0-9])$/.test(document.getElementById(t).value);
-                        if(document.getElementById(t).value=="" || !v) {
-                            alert("  Sorry, please fill in the "+t.split("_").join(" ")+" timestamp\n    in 24 hour, HH:MM:SS format.");
-                            throw BreakException;
-                        }
-                    });
-                }
-                ["full_begins", "full_ends"].forEach((t) => {
-                    let v = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(:[0-5][0-9])$/.test(document.getElementById(t).value);
-                    if(document.getElementById(t).value=="" || !v) {
-                        alert("  Sorry, please fill in the "+t.split("_").join(" ")+" timestamp\n    in 24 hour, HH:MM:SS format.");
-                        throw BreakException;
-                    }
-                });
-            } catch(e) {
-                return;
-            }
+            hideOutput();
 
             ["partialInterval", "partialCount", "bailysInterval", "totalityInterval"].forEach((p) => {
                 let e = document.getElementById(p);
@@ -590,21 +648,21 @@
 
             var esOffset=0;
             if(partialInterval>0 || partialCount>0 ) {
-                addWaitSub('PreEclipseStart',document.getElementById('partial_begins').value,-60);
+                addWaitSub('PreEclipseStart',c1,-60);
                 if(partialCount > 0)
                     esOffset=60;
-                addWaitSub('EclipseStart',document.getElementById('partial_begins').value,esOffset);
+                addWaitSub('EclipseStart', c1, esOffset);
 
-                addWaitSub('PostTotalityPartialStart',document.getElementById('full_ends').value,bailysInterval + 60);
-                addWaitSub('EclipseEnd',document.getElementById('partial_ends').value,esOffset * -1);
-                addWaitSub('PostEclipseEnd',document.getElementById('partial_ends').value,60);
+                addWaitSub('PostTotalityPartialStart', c3, bailysInterval + 60);
+                addWaitSub('EclipseEnd', c4, esOffset * -1);
+                addWaitSub('PostEclipseEnd', c4, 60);
             }
             if(bailysInterval>0)
-                addWaitSub('BailysOneStart',document.getElementById('full_begins').value,bailysInterval*-1);
+                addWaitSub('BailysOneStart', c2, bailysInterval * -1);
 
-            addWaitSub('TotalityStart',document.getElementById('full_begins').value,0);
-            output.push(`    PRESERVE CAMERA SETTINGS`);
-            output.push(`        UNLOCK CONTROLS`);
+            addWaitSub('TotalityStart',c2,0);
+            output.push("    PRESERVE CAMERA SETTINGS");
+            output.push("        UNLOCK CONTROLS");
             output.push("");
             indent=12;
 
@@ -631,7 +689,7 @@
             if(partialInterval>0 || partialCount>0) {
                 if(partialCount > 0) {
                     esOffset = 60;
-                    startTime = secondsToTime(timeToSeconds(document.getElementById('partial_begins').value) - esOffset);
+                    startTime = secondsToTime(c1_seconds - esOffset);
                     preOutput.push("    # Wait until "+startTime);
                     preOutput.push("    # Capture one iteration of 'partialCollection'");
 
@@ -643,8 +701,8 @@
                     output.push(' '.repeat(indent)+"END IF");
                     output.push("")
                 }
-                startTime = secondsToTime(timeToSeconds(document.getElementById('partial_begins').value) + esOffset);
-                stopTime = secondsToTime(timeToSeconds(document.getElementById('full_begins').value) - bailysInterval - 60); // Add in 60 second buffer before next step
+                startTime = secondsToTime(c1_seconds + esOffset);
+                stopTime = secondsToTime(c2_seconds - bailysInterval - 60); // Add in 60 second buffer before next step
                 preOutput.push("    #","    # Wait until "+startTime);
                 output.push(' '.repeat(indent)+"IF EARLIER THAN LOCALTIME "+stopTime);
                 indent+=4;
@@ -659,7 +717,7 @@
              * BEGIN Baily's @ C2 SEQUENCE
              */
              if(bailysInterval>0) {
-                startTime = secondsToTime(timeToSeconds(document.getElementById('full_begins').value)-bailysInterval);
+                startTime = secondsToTime(c2_seconds - bailysInterval);
                 stopTime = document.getElementById('full_begins').value;
                 preOutput.push("    #","    # Wait until "+startTime);
                 output.push(' '.repeat(indent)+"IF EARLIER THAN LOCALTIME "+stopTime);
@@ -667,10 +725,9 @@
                 output.push(' '.repeat(indent)+"GOSUB waitForBailysOneStart");
                 output.push(' '.repeat(indent)+'TARGETNAME "BailysBeadsPreEclipse"');
                 output.push(' '.repeat(indent)+"PLAY SOUND Alert");
-                // output.push(' '.repeat(indent)+'RUN C:\\Windows\\System32\\msg.exe WITH PARAMS "* /time:30 Remove the Solar Filter!" WAIT False')
                 output.push(' '.repeat(indent)+'SHOW NOTIFICATION "Remove the Solar Filter!" COLOUR Green DURATION '+(totalityDuration+bailysInterval).toString());
                 preOutput.push("    # Collect 'bailysCollection' every "+document.getElementById("bailysDelay").value+" seconds, until "+document.getElementById('full_begins').value);
-                addCollection("bailysCollection",document.getElementById('full_begins').value,document.getElementById("bailysDelay").value);
+                addCollection("bailysCollection",c2,document.getElementById("bailysDelay").value);
                 indent-=4;
                 output.push(' '.repeat(indent)+"END IF");
                 output.push("");
@@ -678,19 +735,18 @@
             /* 
              * BEGIN Totality @ C2 SEQUENCE
              */
-            stopTime = document.getElementById("full_ends").value;
+            stopTime = c3;
             output.push(' '.repeat(indent)+"IF EARLIER THAN LOCALTIME "+stopTime);
             indent+=4;
-            preOutput.push("    #","    # Wait until "+document.getElementById('full_begins').value);
+            preOutput.push("    #","    # Wait until "+c2);
             output.push(' '.repeat(indent)+"GOSUB waitForTotalityStart");
             if(partialInterval==0 && partialCount==0 && bailysInterval==0) {
                 output.push(' '.repeat(indent)+"PLAY SOUND Alert");
-                // output.push(' '.repeat(indent)+'RUN C:\\Windows\\System32\\msg.exe WITH PARAMS "* /time:30 Remove the Solar Filter!" WAIT False')
                 output.push(' '.repeat(indent)+'SHOW NOTIFICATION "Remove the Solar Filter!" COLOUR Green DURATION '+totalityDuration.toString());
             }
             output.push(' '.repeat(indent)+'TARGETNAME "FullEclipse"');
             preOutput.push("    # Collect 'totalityCollection' every "+document.getElementById("totalityDelay").value+" seconds, until "+document.getElementById('full_ends').value);
-            addCollection("totalityCollection",document.getElementById("full_ends").value,document.getElementById("totalityDelay").value);
+            addCollection("totalityCollection",c3,document.getElementById("totalityDelay").value);
             indent-=4;
             output.push(' '.repeat(indent)+"END IF");
             output.push("");
@@ -698,7 +754,7 @@
              * BEGIN Baily's @ C3 SEQUENCE
              */
             if(bailysInterval>0) {
-                stopTime = secondsToTime(timeToSeconds(document.getElementById('full_ends').value)+bailysInterval);
+                stopTime = secondsToTime(c3_seconds + bailysInterval);
                 output.push(' '.repeat(indent)+"IF EARLIER THAN LOCALTIME "+stopTime);
                 indent+=4;
                 preOutput.push("    #","    # Collect 'bailysCollection' every "+document.getElementById("bailysDelay").value+" seconds, until "+secondsToTime(timeToSeconds(document.getElementById('full_ends').value)+bailysInterval));
@@ -709,10 +765,9 @@
                 output.push("");
             }
 
-            output.push(' '.repeat(indent)+"IF EARLIER THAN LOCALTIME "+secondsToTime(timeToSeconds(document.getElementById('full_ends').value) + bailysInterval));
+            output.push(' '.repeat(indent)+"IF EARLIER THAN LOCALTIME " + secondsToTime(c3_seconds + bailysInterval));
             indent+=4;
             output.push(' '.repeat(indent)+"PLAY SOUND Error");
-            // output.push(' '.repeat(indent)+'RUN C:\\Windows\\System32\\msg.exe WITH PARAMS "* /time:30 URGENT! ---- Apply the Solar Filter! ---- URGENT!" WAIT False')
             output.push(' '.repeat(indent)+'SHOW NOTIFICATION "URGENT!   Apply the Solar Filter!   URGNET!" COLOUR Red DURATION 120');
             indent-=4;
             output.push(' '.repeat(indent)+"END IF");
@@ -722,8 +777,8 @@
              * BEGIN Partial @ C3 SEQUENCE
              */
              if(partialInterval>0 || partialCount>0) {
-                startTime = secondsToTime(timeToSeconds(document.getElementById('full_ends').value) + bailysInterval + 60);
-                stopTime = secondsToTime(timeToSeconds(document.getElementById('partial_ends').value) - esOffset);
+                startTime = secondsToTime(c3_seconds + bailysInterval + 60);
+                stopTime = secondsToTime(c4_seconds - esOffset);
                 preOutput.push("    #","    # Wait until " + startTime);
                 output.push(' '.repeat(indent)+"IF EARLIER THAN LOCALTIME " + stopTime);
                 indent+=4;
@@ -737,11 +792,10 @@
 
                 if(partialCount > 0) {
                     esOffset = 60;
-                    startTime = secondsToTime(timeToSeconds(document.getElementById('partial_ends').value) + esOffset);
-                    stopTime = secondsToTime(timeToSeconds(document.getElementById('partial_ends').value) + esOffset);
+                    startTime = secondsToTime(c4_seconds + esOffset);
                     preOutput.push("    #","    # Wait until " + startTime);
                     preOutput.push("    # Capture one iteration of 'partialCollection'");
-                    output.push(' '.repeat(indent)+"IF EARLIER THAN LOCALTIME " + stopTime);
+                    output.push(' '.repeat(indent)+"IF EARLIER THAN LOCALTIME " + startTime);
                     indent+=4;
                     output.push(' '.repeat(indent)+"GOSUB waitForPostEclipseEnd");
                     output.push(' '.repeat(indent)+"GOSUB partialCollection");
@@ -751,17 +805,63 @@
                 }
             }
             output.push(' '.repeat(indent)+"PLAY SOUND Alert");
-            // output.push(' '.repeat(indent)+'RUN C:\\Windows\\System32\\msg.exe WITH PARAMS "* /time:30 Solar Eclipse Collection is Complete!" WAIT False')
             output.push(' '.repeat(indent)+'SHOW NOTIFICATION "Solar Eclipse Collection is complete!" COLOUR Green DURATION 120');
 
-            output.push(`        END UNLOCK`);
-            output.push(`    END PRESERVE`);
+            output.push("        END UNLOCK");
+            output.push("    END PRESERVE");
             output.push("END SEQUENCE");
             preOutput.push("    #","    # ## End Sequence","    #","    #");
 
-            document.getElementById("SharpCapSequence").value = preOutput.join("\n") + "\n\n" + output.join("\n");
+            if ( generatePSConfigEl.value === 'Yes' ) {
+                let psConfigOptionNotificationsEl = document.getElementById( 'psConfigOptionNotifications' ),
+                    displayWindowsNotifications = ( psConfigOptionNotificationsEl.value === 'Yes' ) ? '$true' : '$false',
+                    psParams = "-display_windows_notifications " + displayWindowsNotifications;
+                if ( c1 != "" )
+                    psParams += " -c1 "+c1;
+                psParams += " -c2 " + c2 + " -c3 " + c3
+                if ( c4 != "" )
+                    psParams += " -c4 "+c4;
+
+                preOutput.push("", "    # Powershell Script", "    RUN PowerShell WITH PARAMS \"-NoProfile -ExecutionPolicy Bypass -WindowStyle Minimized -Command .\\scripts\\eclipse\\april-2024-solar-eclipse.ps1 "+psParams+"\" WAIT False" );
+
+            }
+
+            SharpCapSequenceEl.value = preOutput.join("\n") + "\n\n" + output.join("\n");
+
+            // Start a new thread
+            /*
+            setTimeout( function() {
+                SharpCapSequenceEl.scrollTop = 0;
+            }, 1 );
+            */
+
             document.getElementById("sequenceDiv").style.display = "block";
+
             window.scrollTo(0, document.body.scrollHeight);
+        }
+
+
+        function checkPSConfigOptions() {
+            let generatePSConfigEl = document.getElementById( 'generatePSConfig' ),
+                shouldGeneratePSConfig = ( generatePSConfigEl.value === 'Yes' ),
+                disablePSConfigOptionEls = ( ! shouldGeneratePSConfig ),
+                psConfigOptionEls = document.querySelectorAll( '.psConfigOption' );
+
+            psConfigOptionEls.forEach( async function( el ) {
+                el.disabled = ( disablePSConfigOptionEls );
+
+                if ( disablePSConfigOptionEls ) {
+                    el.setAttribute( 'disabled', ( ! shouldGeneratePSConfig ) ? 'disabled' : '' );
+                    document.getElementById("psDownloadButton").style.display = "none";
+                }
+                else {
+                    el.removeAttribute( 'disabled' );
+                    document.getElementById("psDownloadButton").style.display = "inline-block";
+                }
+            } );
+
+
+            hideOutput();
         }
 
         function copyToClipboard() {
@@ -769,26 +869,27 @@
         }
 
         function downloadSequence() {
-            var textToSave = document.getElementById("SharpCapSequence").value;
-            var textToSaveAsBlob = new Blob([textToSave], {type:"text/plain"});
-            var textToSaveAsURL = window.URL.createObjectURL(textToSaveAsBlob);
-            var fileNameToSaveAs = "SharpCap_Eclipse_Sequence.scs";
-
-            var downloadLink = document.createElement("a");
-            downloadLink.download = fileNameToSaveAs;
-            downloadLink.innerHTML = "Download File";
-            downloadLink.href = textToSaveAsURL;
-            downloadLink.onclick = destroyClickedElement;
-            downloadLink.style.display = "none";
-            document.body.appendChild(downloadLink);
-
-            downloadLink.click();
+            downloadFile('SharpCap_Eclipse_Sequence.scs',document.getElementById("SharpCapSequence").value);
         }
 
-        function destroyClickedElement(event) {
-            document.body.removeChild(event.target);
+        function downloadPSScript() {
+            fetch('scripts/powershell/april-2024-solar-eclipse.ps1')
+            .then(response => response.text())
+            .then((data) => {
+                downloadFile('april-2024-solar-eclipse.ps1',data);
+            })
         }
 
+        function downloadFile(filename,text) {
+            var element = document.createElement('a');
+            element.setAttribute('href',
+                'data:text/plain;charset=utf-8, '
+                + encodeURIComponent(text));
+            element.setAttribute('download', filename);
+            document.body.appendChild(element);
+            element.click();
+            document.body.removeChild(element);
+        }
 
         function parseSavedParams(params) {
             for( const [k,v] of Object.entries(params) ) {
@@ -799,7 +900,6 @@
                 }
             }
         }
-
 
         function parseSavedPlans(plans) {
             for( const [p,rows] of Object.entries(plans) ) {
@@ -867,7 +967,11 @@
             else
                 var params = {};
 
-            ["partial_begins", "partial_ends","full_begins", "full_ends","bailysInterval","partialInterval", "partialCount","gain","offset","output","profile","bailysDelay","totalityDelay"].forEach((a) => {
+            ["partial_begins", "partial_ends","full_begins", "full_ends",
+             "bailysInterval","partialInterval", "partialCount",
+             "gain","offset","output","profile",
+             "bailysDelay","totalityDelay",
+             "generatePSConfig","psConfigOptionNotifications"].forEach((a) => {
                 params[a]=document.getElementById(a).value;
                 if(hashMode) {
                         params.push(a+'='+document.getElementById(a).value)
@@ -896,6 +1000,7 @@
                 parseSavedPlans(JSON.parse(ls.getItem('plans')));
         }
 
+        const timeRegEx = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(:[0-5][0-9])$/;
         readURL();
         loadState();
 
@@ -904,6 +1009,7 @@
         checkVisible("partialInterval");
         checkVisible("partialCount");
         checkVisible("bailysInterval");
+        checkPSConfigOptions();
         setTimeout(function() {["partial_begins","full_begins","full_ends","partial_ends"].forEach((t) => verifyTime(document.getElementById(t)));},500);
         
     </script>

--- a/scripts/powershell/april-2024-solar-eclipse.ps1
+++ b/scripts/powershell/april-2024-solar-eclipse.ps1
@@ -1,0 +1,344 @@
+#######################################################################
+# Note: This script is called from within the root SharpCap directory #
+#######################################################################
+
+#################
+# Configuration #
+#################
+
+param (
+	[string]$c1 = "",
+	[Parameter(Mandatory=$true)][string]$c2,
+	[Parameter(Mandatory=$true)][string]$c3,
+	[string]$c4 = "",
+	[bool]$display_windows_notifications = $true
+)
+
+$times = @{ "c1"=$c1; "c2"=$c2; "c3"=$c3; "c4"=$c4; "max_eclipse_offset"=[Math]::Floor(( ( Get-Date $c3 ) - ( Get-Date $c2 ) ).TotalSeconds / 2 ) }
+
+##################
+# Alerts to send #
+##################
+
+$alerts = @(
+    @{'base'='c1'; 'offset'=-120; 'tts'='The SharpCap eclipse script has started'; 'title'='SharpCap Script - Started'},
+    @{'base'='c1'; 'offset'=-60; 'tts'='First contact is in 60 seconds'; 'title'='First Contact In 60 Seconds'},
+    @{'base'='c1'; 'offset'=-30; 'tts'='30 seconds'; 'title'='First Contact In 30 Seconds'},
+    @{'base'='c1'; 'offset'=-20; 'tts'='20 seconds'; 'title'='First Contact In 20 Seconds'},
+    @{'base'='c1'; 'offset'=-10; 'tts'='10 seconds'; 'title'='First Contact In 10 Seconds'},
+    @{'base'='c1'; 'offset'=0; 'tts'='First contact is happening now'; 'title'='First contact Now'; 'type'='Warning'},
+
+    @{'base'='c2'; 'offset'=-1500; 'tts'='Refocus telescope if necessary'; 'title'='Refocus Telescope'},
+    @{'base'='c2'; 'offset'=-1200; 'tts'='Look for Venus at about 5 o''clock in relation to the sun'; 'title'='Look for Venus'},
+    @{'base'='c2'; 'offset'=-600; 'tts'='Look for Venus at about 5 o''clock in relation to the sun'; 'title'='Look for Venus'},
+    @{'base'='c2'; 'offset'=-300; 'tts'='Look for Venus at about 5 o''clock in relation to the sun'; 'title'='Look for Venus'},
+    @{'base'='c2'; 'offset'=-180; 'tts'='Totality is in 3 minutes'; 'title'='Totality in 3 Minutes'},
+    @{'base'='c2'; 'offset'=-120; 'tts'='Totality is in 2 minutes'; 'title'='Totality in 2 Minutes'},
+    @{'base'='c2'; 'offset'=-90; 'tts'='Look for Jupiter at about 11 o''clock in relation to the sun'; 'title'='Look for Jupiter'},
+    @{'base'='c2'; 'offset'=-60; 'tts'='Totality is in 1 minute'; 'title'='Totality in 1 Minute'},
+    @{'base'='c2'; 'offset'=-33; 'tts'='Remove solar filter'; 'title'='Remove Solar Filter'; 'type'='Warning'},
+    @{'base'='c2'; 'offset'=-30; 'tts'='30 seconds'; 'title'='Totality in 30 Seconds'},
+    @{'base'='c2'; 'offset'=-20; 'tts'='20 seconds'; 'title'='Totality in 20 Seconds'},
+    @{'base'='c2'; 'offset'=-10; 'tts'='10 seconds'; 'title'='Totality in 10 Seconds'},
+    @{'base'='c2'; 'offset'=-8; 'tts'='Look for diamond ring'; 'title'='Diamond Ring'; 'type'='Warning'},
+    @{'base'='c2'; 'offset'=-5; 'tts'='Look for Baily''s Beads'; 'title'='Baily''s Beads'; 'type'='Warning'},
+    @{'base'='c2'; 'offset'=0; 'tts'='Totality starts now'; 'title'='Totality Starts'; 'type'='Warning'},
+
+    @{'base'='c2'; 'offset'=20; 'tts'='Observe the horizon'; 'title'='Observe the Horizon'},
+    @{'base'='c2'; 'offset'=50; 'tts'='Look for comet 12P (Pons-Brooks) near Jupiter at about 4 o''clock in relation to Jupiter. This comet will appear between Jupiter and the Sun if visible.'; 'title'='Comet 12P (Pons-Brooks)'},
+    @{'base'='c2'; 'offset'=$times["max_eclipse_offset"]; 'tts'='Maximum eclipse is happening now'; 'title'='Maximum Eclipse Now';'type'='Warning'},
+    @{'base'='c2'; 'offset'=80; 'tts'='Observe the horizon'; 'title'='Observe the Horizon'},
+
+    @{'base'='c3'; 'offset'=-60; 'tts'='Totality ends in 60 seconds'; 'title'='Totality Ends in 60 seconds'},
+    @{'base'='c3'; 'offset'=-30; 'tts'='30 seconds'; 'title'='Totality ends in 30 seconds'},
+    @{'base'='c3'; 'offset'=-20; 'tts'='20 seconds'; 'title'='Totality ends in 30 seconds'},
+    @{'base'='c3'; 'offset'=-10; 'tts'='10 seconds'; 'title'='Totality ends in 10 seconds'},
+    @{'base'='c3'; 'offset'=0; 'tts'='Totality ending now'; 'title'='Totality Ending Now';'type'='Warning'},
+    @{'base'='c3'; 'offset'=3; 'tts'='Look for Baily''s Beads'; 'title'='Baily''s Beads';'type'='Warning'},
+    @{'base'='c3'; 'offset'=6; 'tts'='Look for diamond ring'; 'title'='Diamond Ring'},
+    @{'base'='c3'; 'offset'=32; 'tts'='Warning, Replace Solar Filter'; 'title'='Replace Solar Filter';'type'='Warning'},
+    @{'base'='c3'; 'offset'=60; 'tts'='Jupiter should disappear shortly'; 'title'='Jupiter Disappearing'},
+    @{'base'='c3'; 'offset'=300; 'tts'='Venus should disappear shortly'; 'title'='Venus Disappearing'},
+    @{'base'='c3'; 'offset'=600; 'tts'='Venus should disappear shortly'; 'title'='Venus Disappearing'},
+    @{'base'='c3'; 'offset'=1200; 'tts'='Venus should disappear shortly'; 'title'='Venus Disappearing'},
+    @{'base'='c3'; 'offset'=1500; 'tts'='Refocus telescope if necessary'; 'title'='Refocus Telescope'},
+
+    @{'base'='c4'; 'offset'=-60; 'tts'='Last contact in 60 seconds'; 'title'='Last Contact'},
+    @{'base'='c4'; 'offset'=-30; 'tts'='30 seconds'; 'title'='Last Contact in 30 seconds'},
+    @{'base'='c4'; 'offset'=-20; 'tts'='20 seconds'; 'title'='Last Contact in 20 seconds'},
+    @{'base'='c4'; 'offset'=-10; 'tts'='10 seconds'; 'title'='Last Contact in 10 seconds'},
+    @{'base'='c4'; 'offset'=0; 'tts'='Last contact is happening now'; 'title'='Last Contact'; 'type'='Warning'}
+)
+
+
+#############
+# Functions #
+#############
+
+##
+# This function returns the current time.
+#
+# @returns string
+#
+function getCurrentTime {
+	( Get-Date ).ToString( 'HH:mm:ss' )
+}
+
+##
+# This function returns an offset between a timestamp and the current time.
+#
+# @param string $timestamp
+#
+# @returns double
+#
+function getTimestampFromCurrentTime {
+	param (
+		[ Parameter( Mandatory, Position = 0 ) ]
+		[ String ] $timestamp
+	)
+
+	$timestamp_offset = ( ( Get-Date $timestamp ) - ( Get-Date ) ).TotalSeconds
+
+	[ Double ] $timestamp_offset
+}
+
+##
+# This function sleeps until a specific time.
+#
+# @param string $timestamp
+#
+# @returns string
+#
+function sleepUntil {
+	param (
+		[ Parameter( Mandatory, Position = 0 ) ]
+		[ String ] $timestamp
+	)
+
+	$timestamp_offset = getTimestampFromCurrentTime $timestamp
+	$current_time = getCurrentTime
+	$do_sleep = if ( $timestamp_offset -gt 0 ) { $true } else { $false }
+
+	if ( $do_sleep ) {
+		Write-Information "$current_time`: Waiting until $timestamp ($timestamp_offset seconds)..." -InformationAction Continue
+
+		Start-Sleep -Seconds $timestamp_offset
+	}
+	else {
+		Write-Information "$current_time`: $timestamp is before the current time, skipping sleep" -InformationAction Continue
+	}
+
+	return $do_sleep
+}
+
+##
+# This function plays a TTS (text-to-speech) sound.
+#
+# Note: Calling this function consecutively will result in
+# only the last sound playing through the speakers.
+#
+# @param string $text
+#
+# @returns void
+#
+function playTTSSound {
+	param (
+		[ Parameter( Mandatory, Position = 0 ) ]
+		[ String ] $text
+	)
+
+	$current_time = getCurrentTime
+	Write-Information "$current_time`: Play TTS sound (""$text"")" -InformationAction Continue
+
+	Add-Type -AssemblyName System.Speech
+
+	$tts = ( New-Object System.Speech.Synthesis.SpeechSynthesizer );
+	$tts.Volume = 100
+
+	$tts.SpeakAsyncCancelAll();
+
+	$tts.SetOutputToDefaultAudioDevice();
+
+	$tts.SpeakAsync( $text );
+}
+
+##
+# This function initializes the script.
+#
+# @returns string
+#
+function initializeScript {
+	param (
+		[ Parameter( Mandatory, Position = 0 ) ]
+		[ String ] $script_start_time
+	)
+
+	$current_time = getCurrentTime
+	$initialized_timestamp_offset = getTimestampFromCurrentTime $script_start_time
+
+	Write-Information "$current_time`: SharpCap Powershell Eclipse Script Initialized" -InformationAction Continue
+	Write-Information "$current_time`: ----------------------------------------------" -InformationAction Continue
+	Write-Information "" -InformationAction Continue
+
+	if ( $initialized_timestamp_offset -gt 0 ) {
+		if ( $display_windows_notifications ) {
+			showNotifyIcon 'SharCap Script - Initialized' 'The SharpCap eclipse script has been initialized and is waiting to start' 'Info'
+		}
+
+		playTTSSound 'The SharpCap eclipse script has been initialized and is waiting to start'
+	}
+	else {
+		Write-Information "$current_time`: Skipping initialize alert" -InformationAction Continue
+	}
+}
+
+##
+# This function displays a Windows notification.
+#
+# @param string $title
+# @param string $text
+# @param string $icon_type
+# @param string $timeout
+#
+# @returns void
+#
+function showNotifyIcon {
+	[CmdletBinding()]
+
+	param (
+		[ Parameter( Mandatory, Position = 0 ) ]
+		[ String ] $title,
+
+		[ Parameter( Mandatory, Position = 1 ) ]
+		[ ValidateNotNullOrEmpty() ]
+		[ String ] $text,
+
+		[ Parameter( Position = 2 ) ]
+		[ ValidateSet( "Error", "Info", "None", "Warning" ) ]
+		[ String ] $icon_type = 'Info',
+
+		[ Parameter( Position = 3 ) ]
+		[ Int ] $timeout = 10000
+	)
+
+	$current_time = getCurrentTime
+	Write-Information "$current_time`: Showing notification ($title)" -InformationAction Continue
+
+	Add-Type -AssemblyName "System.Windows.Forms"
+
+	if ( ! ( Test-Path -Path Variable:\Script:icon ) ) {
+		$ps_exe = Join-Path $PSHOME "powershell.exe" -Resolve
+		$Script:icon = [ Drawing.Icon ]::ExtractAssociatedIcon( $ps_exe )
+	}
+
+	$NotifyIcon = ( New-Object System.Windows.Forms.NotifyIcon )
+	$NotifyIcon.Icon = $Script:icon;
+	$NotifyIcon.Visible = $true;
+
+	$NotifyIcon.ShowBalloonTip( $timeout, $title, $text, [ Windows.Forms.ToolTipIcon ] $icon_type )
+
+	# Note: On Windows 11, calling $NotifyIcon.Dispose(); right after $NotifyIcon.ShowBalloonTip()
+	# helps to ensure the notification is removed from the system tray and also the notifications center
+	# automatically after some time. It also helps to ensure the notifications are removed from the system
+	# tray when the script exits. However, this does affect the notification window title (the Powershell
+	# application is not named).
+	$null = $NotifyIcon.Dispose();
+}
+
+##
+# This function sleeps until a specified timestamp and then triggers an audible alert. It may also trigger a Windows Notification.
+#
+# @param string $timestamp
+# @param string $sound_path
+# @param string $tts_text
+# @param string $notification_title
+# @param string $notification_text
+# @param string $notification_icon_type
+# @param int $notification_timeout
+#
+# @uses $display_windows_notifications
+# @uses $use_tts
+#
+# @returns void
+#
+function sleepUntilAndThenTriggerAlert {
+	param (
+   		[ Parameter( Mandatory, Position = 0 ) ]
+		[ String ] $timestamp,
+
+		[ Parameter( Mandatory, Position = 1 ) ]
+		[ String ] $tts_text,
+
+		[ Parameter( Mandatory, Position = 2 ) ]
+		[ string ] $notification_title,
+
+		[ Parameter( Position = 3 ) ]
+		[ ValidateSet( "Error", "Info", "None", "Warning" ) ]
+		[ String ] $notification_icon_type = 'Info',
+
+		[ Parameter( Position = 4 ) ]
+		[ Int ] $notification_timeout = 10000
+	)
+
+	$current_time = getCurrentTime
+	$did_sleep = sleepUntil( $timestamp )
+
+	if ( $did_sleep ) {
+		if ( $display_windows_notifications ) {
+			showNotifyIcon $notification_title $tts_text $notification_icon_type $notification_timeout
+		}
+
+		playTTSSound $tts_text
+	}
+	else {
+		Write-Information "$current_time`: Skipping alert ($notification_title)" -InformationAction Continue
+	}
+
+	Write-Information "" -InformationAction Continue
+}
+
+
+##########
+# Script #
+##########
+
+# Initialize
+
+$initSent = $false
+$lastAlert = @{}
+
+$skipPartial = $false
+if ( $times['c1'] -eq "" -or $times['c4'] -eq "" ) {
+	$skipPartial = $true
+}
+
+
+ForEach($alert in $alerts) {
+	if ( $times[$alert['base']] -ne "") {
+		if ( $skipPartial -and [Math]::Abs($alert['offset']) -gt 299 ) {
+			Continue
+		}
+		if( -Not $initSent ) {
+			initializeScript ( Get-Date $times[$alert['base']] ).AddSeconds( $alert['offset'] + -10 ).ToString( 'HH:mm:ss' )
+			$initSent = $true
+		}
+
+		$type = 'Info'
+		if ( $alert.ContainsKey('type') ) {
+			$type = $alert['type']
+		}
+		$startTime = ( Get-Date $times[$alert['base']] ).AddSeconds( $alert['offset'] ).ToString( 'HH:mm:ss' )
+		sleepUntilAndThenTriggerAlert $startTime $alert['tts'] $alert['title'] $type
+		$lastAlert = $alert;
+	}
+}
+
+sleepUntil ( Get-Date $times[$lastAlert['base']] ).AddSeconds( $lastAlert['offset'] + 30 ).ToString( 'HH:mm:ss' )
+Write-Information "Exiting..." -InformationAction Continue
+if ( $display_windows_notifications ) {
+	showNotifyIcon 'SharpCap Script - Ended' 'The SharpCap eclipse script has ended'
+}
+
+playTTSSound 'The SharpCap eclipse script has ended, exiting.'
+# Exit (5 seconds after the script end alert)
+sleepUntil ( Get-Date $times[$lastAlert['base']] ).AddSeconds( $lastAlert['offset'] + 35 ).ToString( 'HH:mm:ss' )


### PR DESCRIPTION
This update provides a powershell script, originally authored by @scottsousa via pr #2.

The script is a companion which is executed during the SharpCap Sequence and runs in parallel to provide Windows notifications and Test 2 Speech prompts of key events during the Eclipse.

The announced events can be seen / edited in the [april-2024-solar-eclipse.ps1](scripts/powershell/april-2024-solar-eclipse.ps1) file.

The script takes 5 parameters, with only 2 being required:
* `-c1`, `-c4` == The 24 hour time designation for the start and end of the Partial Solar Eclipse ( Optional - if not provided, partial announcements will be skipped )
* `-c2`, `-c3` == The 24 hour time designation for the start and end of the Total Solar Eclipse ( Required )
* `-display_windows_notifications` == Boolean for disabling the Windows Toast notifications ( Optional - Default: `$true` )

Example use:
```
PowerShell -NoProfile -ExecutionPolicy Bypass -WindowStyle Minimized -Command .\april-2024-solar-eclipse.ps1 -display_windows_notifications $true -c1 12:23:51 -c2 13:41:14 -c3 13:45:08 -c4 15:03:09
```
