### PR TITLE
Fix missing gain and offset sequence steps when set to zero

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,10 +805,10 @@
             output.push(' '.repeat(indent)+'ARRANGE FILES IN ONE FOLDER');
             output.push(' '.repeat(indent)+'TARGETNAME "PartialPreEclipse"');
 
-            if(p["gain"]!="")
+            if(p["gain"]!=="")
                 output.push(' '.repeat(indent)+"SET GAIN TO "+p["gain"]);
 
-                if(p["offset"]!="")
+                if(p["offset"]!=="")
                 output.push(' '.repeat(indent)+"SET OFFSET to "+p["offset"]);
 
                 output.push(' '.repeat(indent)+'SET OUTPUT FORMAT TO "'+document.getElementById("output").value+'"');


### PR DESCRIPTION
Hi @linuxkidd ,

I noticed an issue with the sequencer when the gain and offset are set to zero.

# Description

This pull request adds strict type checking to ensure values of zero are properly accounted for in the sequencer script.

Let me know if you have any questions!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

To reproduce, set either the gain or offset (or both) inputs to zero in the current version of the script. The corresponding steps are not included in the sequencer script.

This PR accounts for values of zero so that that the corresponding SharpCap steps for gain and offset are included in the sequencer script.

# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings